### PR TITLE
Fix: disable wipeStorage to prevent losing data for Redis adapter

### DIFF
--- a/src/Actions/RenderCollectorsAction.php
+++ b/src/Actions/RenderCollectorsAction.php
@@ -27,10 +27,6 @@ class RenderCollectorsAction
 
         $metricSamples = $this->registry->getMetricFamilySamples();
 
-        $result = $renderer->render($metricSamples);
-
-        $this->registry->wipeStorage();
-
-        return $result;
+        return $renderer->render($metricSamples);
     }
 }


### PR DESCRIPTION
I offer to disable `wipeStorage` to prevent losing data for `Redis` adapter:

I use in  an app `Redis` storage for CollectorRegistry:
```php
$this->app->scoped(CollectorRegistry::class, function () {
            $client = $this->app->get('redis.connection')->client();

            return new CollectorRegistry(RedisStorage::fromExistingConnection($client), false);
});
```

Default `RenderCollectorsAction` flush each time storage which loses data for `Redis` adapter.