### PR TITLE
add ext-redis to dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ You can find full documentation on [our dedicated documentation site](https://do
 
 ## Testing
 
+To run the horizon collector tests you need to install the redis extension.
+
+On Ubuntu you can do so with the following command:
+
+```bash
+sudo apt-get install php-redis
+```
+
+On MacOS you can do so with the following command:
+
+```bash
+pecl install redis
+```
+
+To run the tests call `composer test`:
+
 ```bash
 composer test
 ```

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {
+        "ext-redis": "*",
         "laravel/horizon": "^5.16.1",
         "laravel/pint": "^1.10",
         "mockery/mockery": "^1.6",


### PR DESCRIPTION
The tests wont run without the redis extension as it is the default storage system for horizon.