### PR TITLE
Laravel cache adapter

### DIFF
--- a/config/prometheus.php
+++ b/config/prometheus.php
@@ -43,4 +43,17 @@ return [
      * Allow storage to be wiped after a render of data in metrics controller.
      */
     'wipe_storage_after_rendering' => false,
+
+    /**
+     * Select a cache to store gauges, counters, summaries and histograms between requests.
+     * In a multi node setup you should ensure that each node writes to its own
+     * cache instance or uses a node specific prefix.
+     * Configure the cache store in config/cache.php.
+     *
+     * to use an in memory adapter for testing use array or null as your store
+     * or remove the cache entry all together:
+     *  'cache' => null       // InMemory implementation without laravel cache
+     *  'cache' => 'array'    // InMemory implementation using laravel cache
+     */
+    'cache' => null,
 ];

--- a/src/Adapters/LaravelCacheAdapter.php
+++ b/src/Adapters/LaravelCacheAdapter.php
@@ -12,11 +12,14 @@ use Prometheus\Summary;
 class LaravelCacheAdapter extends InMemory
 {
     private const CACHE_KEY_PREFIX = 'PROMETHEUS_';
+
     private const CACHE_KEY_SUFFIX = '_METRICS';
+
     private const STORES = [Gauge::TYPE, Counter::TYPE, Histogram::TYPE, Summary::TYPE];
 
     public function __construct(private readonly Repository $cache)
-    {}
+    {
+    }
 
     public function collect(bool $sortMetrics = true): array
     {
@@ -58,7 +61,7 @@ class LaravelCacheAdapter extends InMemory
     public function wipeStorage(): void
     {
         $this->cache->deleteMultiple(
-            array_map(fn($store) => $this->cacheKey($store), self::STORES)
+            array_map(fn ($store) => $this->cacheKey($store), self::STORES)
         );
     }
 

--- a/src/Adapters/LaravelCacheAdapter.php
+++ b/src/Adapters/LaravelCacheAdapter.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Spatie\Prometheus\Adapters;
+
+use Illuminate\Contracts\Cache\Repository;
+use Prometheus\Counter;
+use Prometheus\Gauge;
+use Prometheus\Histogram;
+use Prometheus\Storage\InMemory;
+use Prometheus\Summary;
+
+class LaravelCacheAdapter extends InMemory
+{
+    private const CACHE_KEY_PREFIX = 'PROMETHEUS_';
+    private const CACHE_KEY_SUFFIX = '_METRICS';
+    private const STORES = [Gauge::TYPE, Counter::TYPE, Histogram::TYPE, Summary::TYPE];
+
+    public function __construct(private readonly Repository $cache)
+    {}
+
+    public function collect(bool $sortMetrics = true): array
+    {
+        foreach (self::STORES as $store) {
+            $this->fetch($store);
+        }
+
+        return parent::collect($sortMetrics);
+    }
+
+    public function updateSummary(array $data): void
+    {
+        $this->summaries = $this->fetch(Summary::TYPE);
+        parent::updateSummary($data);
+        $this->update(Summary::TYPE, $this->summaries);
+    }
+
+    public function updateHistogram(array $data): void
+    {
+        $this->histograms = $this->fetch(Histogram::TYPE);
+        parent::updateHistogram($data);
+        $this->update(Histogram::TYPE, $this->histograms);
+    }
+
+    public function updateGauge(array $data): void
+    {
+        $this->counters = $this->fetch(Gauge::TYPE);
+        parent::updateGauge($data);
+        $this->update(Gauge::TYPE, $this->counters);
+    }
+
+    public function updateCounter(array $data): void
+    {
+        $this->counters = $this->fetch(Counter::TYPE);
+        parent::updateCounter($data);
+        $this->update(Counter::TYPE, $this->counters);
+    }
+
+    public function wipeStorage(): void
+    {
+        $this->cache->deleteMultiple(
+            array_map(fn($store) => $this->cacheKey($store), self::STORES)
+        );
+    }
+
+    private function fetch(string $type): array
+    {
+        return $this->cache->get($this->cacheKey($type), []);
+    }
+
+    private function update(string $type, $data): void
+    {
+        $this->cache->put($this->cacheKey($type), $data);
+    }
+
+    private function cacheKey(string $type): string
+    {
+        return self::CACHE_KEY_PREFIX.$type.self::CACHE_KEY_SUFFIX;
+    }
+}

--- a/src/Adapters/LaravelCacheAdapter.php
+++ b/src/Adapters/LaravelCacheAdapter.php
@@ -46,9 +46,9 @@ class LaravelCacheAdapter extends InMemory
 
     public function updateGauge(array $data): void
     {
-        $this->counters = $this->fetch(Gauge::TYPE);
+        $this->gauges = $this->fetch(Gauge::TYPE);
         parent::updateGauge($data);
-        $this->update(Gauge::TYPE, $this->counters);
+        $this->update(Gauge::TYPE, $this->gauges);
     }
 
     public function updateCounter(array $data): void

--- a/src/PrometheusServiceProvider.php
+++ b/src/PrometheusServiceProvider.php
@@ -2,12 +2,15 @@
 
 namespace Spatie\Prometheus;
 
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
 use Prometheus\CollectorRegistry;
+use Prometheus\Storage\Adapter;
 use Prometheus\Storage\InMemory;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\Prometheus\Adapters\LaravelCacheAdapter;
 use Spatie\Prometheus\Http\Controllers\PrometheusMetricsController;
 use Spatie\Prometheus\Http\Middleware\AllowIps;
 
@@ -33,7 +36,10 @@ class PrometheusServiceProvider extends PackageServiceProvider
         $this->app->alias(Prometheus::class, 'prometheus');
 
         $this->app->scoped(CollectorRegistry::class, function () {
-            return new CollectorRegistry(new InMemory(), false);
+            return new CollectorRegistry(
+                $this->buildStorageAdapter(config('prometheus.cache')),
+                false
+            );
         });
     }
 
@@ -55,5 +61,14 @@ class PrometheusServiceProvider extends PackageServiceProvider
         }
 
         return $this;
+    }
+
+    private function buildStorageAdapter(?string $adapter): Adapter
+    {
+        if ($adapter === null) {
+            return new InMemory();
+        }
+
+        return new LaravelCacheAdapter(Cache::resolve($adapter));
     }
 }

--- a/src/PrometheusServiceProvider.php
+++ b/src/PrometheusServiceProvider.php
@@ -63,7 +63,7 @@ class PrometheusServiceProvider extends PackageServiceProvider
         return $this;
     }
 
-    private function buildStorageAdapter(?string $adapter): Adapter
+    protected function buildStorageAdapter(?string $adapter): Adapter
     {
         if ($adapter === null) {
             return new InMemory();


### PR DESCRIPTION
This PR adds a laravel cache adapter, to leverage all of the laravel cache storage implementations.
I manually tested it with the database, redis, file and array drivers.

I'll provide programmatic tests asap, I just need to read up on Pest first.