### PR TITLE
feat: add Conditionable traits to Gauges & docs cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**.
+
+Please read and understand the contribution guide before creating an issue or pull request.
+
+## Etiquette
+
+This project is open source, and as such, the maintainers give their free time to build and maintain the source code
+held within. They make the code freely available in the hope that it will be of use to other developers. It would be
+extremely unfair for them to suffer abuse or anger for their hard work.
+
+Please be considerate towards maintainers when raising issues or presenting pull requests. Let's show the
+world that developers are civilized and selfless people.
+
+It's the duty of the maintainer to ensure that all submissions to the project are of sufficient
+quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
+
+## Viability
+
+When requesting or submitting new features, first consider whether it might be useful to others. Open
+source projects are used by many developers, who may have entirely different needs to your own. Think about
+whether or not your feature is likely to be used by other users of the project.
+
+## Procedure
+
+Before filing an issue:
+
+- Attempt to replicate the problem, to ensure that it wasn't a coincidental incident.
+- Check to make sure your feature suggestion isn't already present within the project.
+- Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
+- Check the pull requests tab to ensure that the feature isn't already in progress.
+
+Before submitting a pull request:
+
+- Check the codebase to ensure that your feature doesn't already exist.
+- Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
+
+## Requirements
+
+If the project maintainer has any additional requirements, you will find them listed here.
+
+- **[PSR-12 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
+
+**Happy coding**!

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ composer test
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
 
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+
 ## Security Vulnerabilities
 
 Please review [our security policy](../../security/policy) on how to report security vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -67,10 +67,6 @@ composer test
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
 
-## Contributing
-
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
-
 ## Security Vulnerabilities
 
 Please review [our security policy](../../security/policy) on how to report security vulnerabilities.

--- a/docs/basic-usage/_index.md
+++ b/docs/basic-usage/_index.md
@@ -8,4 +8,3 @@ This section covers basic usage of the Laravel Prometheus package, including:
 - [Creating gauges]({{< ref "creating-gauges" >}}) - Learn how to create and register custom gauge metrics
 - [Using Horizon exporters]({{< ref "using-horizon-exporters" >}}) - Export Laravel Horizon metrics to Prometheus
 - [Using Queue exporters]({{< ref "using-queue-exporters" >}}) - Export Laravel queue metrics to Prometheus
-- [Using cached values]({{< ref "using-cached-values" >}}) - Optimize performance with cached metric values

--- a/docs/basic-usage/using-cached-values.md
+++ b/docs/basic-usage/using-cached-values.md
@@ -1,6 +1,0 @@
----
-title: Using cached values
-weight: 3
----
-
-Coming soon...

--- a/src/MetricTypes/Counter.php
+++ b/src/MetricTypes/Counter.php
@@ -5,11 +5,14 @@ namespace Spatie\Prometheus\MetricTypes;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Prometheus\CollectorRegistry;
 use Prometheus\Counter as PrometheusCounter;
 
 class Counter implements MetricType
 {
+    use Conditionable;
+
     protected array $values = [];
 
     public function __construct(

--- a/src/MetricTypes/Gauge.php
+++ b/src/MetricTypes/Gauge.php
@@ -5,11 +5,14 @@ namespace Spatie\Prometheus\MetricTypes;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Prometheus\CollectorRegistry;
 use Prometheus\Gauge as PrometheusGauge;
 
 class Gauge implements MetricType
 {
+    use Conditionable;
+
     protected array $values = [];
 
     public function __construct(

--- a/tests/Http/Controllers/PrometheusMetricsControllerTest.php
+++ b/tests/Http/Controllers/PrometheusMetricsControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\Prometheus\Facades\Prometheus;
+use Spatie\Prometheus\MetricTypes\Gauge;
 use Spatie\Prometheus\Tests\TestSupport\Actions\TestRenderCollectorsAction;
 
 it('can render a simple gauge', closure: function () {
@@ -29,7 +30,7 @@ it('can render a gauge with all options', function () {
     /** @var \Spatie\Prometheus\MetricTypes\Gauge $gauge */
     Prometheus::addGauge('my gauge')
         ->namespace('other_namespace')
-        ->helpText('This is the help text')
+        ->when(true, fn (Gauge $gauge): Gauge => $gauge->helpText('This is the help text'))
         ->name('alternative_name')
         ->value(123.45);
 


### PR DESCRIPTION
Heya,

Loving this package, thanks!

---

Docs:
- Removes 'Using cached values' from docs, as it said 'Coming soon...' for years, and I have no idea what it was supposed to do
- Removes Contributing section from README - there is no `CONTRIBUTING.md`

Features:
- Adds `Conditionable` trait from `illuminate/support` to the `Gauge` and `Counter` MetricTypes:
  - allows fluent setting of all properties/setters


```
$random = rand(0, 1);

$gauge = Prometheus::addGauge('key')
  ->label('Custom Key')
  ->when($random === 1, function (Gauge $gauge) {
    $gauge->helpText('For value 1');
  });
```