### PR TITLE
Add explicit return types to service provider and facade methods

### DIFF
--- a/config/prometheus.php
+++ b/config/prometheus.php
@@ -1,5 +1,8 @@
 <?php
 
+use Spatie\Prometheus\Actions\RenderCollectorsAction;
+use Spatie\Prometheus\Http\Middleware\AllowIps;
+
 return [
     'enabled' => true,
 
@@ -28,7 +31,7 @@ return [
      * The middleware that will be applied to the urls above
      */
     'middleware' => [
-        Spatie\Prometheus\Http\Middleware\AllowIps::class,
+        AllowIps::class,
     ],
 
     /*
@@ -36,7 +39,7 @@ return [
      * In most cases, you can just use the defaults.
      */
     'actions' => [
-        'render_collectors' => Spatie\Prometheus\Actions\RenderCollectorsAction::class,
+        'render_collectors' => RenderCollectorsAction::class,
     ],
 
     /**

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -78,7 +78,7 @@ use Spatie\Prometheus\Facades\Prometheus;
 
 class PrometheusServiceProvider extends ServiceProvider
 {
-    public function register()
+    public function register(): void
     {
         /*
          * Here you can register all the exporters that you

--- a/resources/stubs/PrometheusServiceProvider.php.stub
+++ b/resources/stubs/PrometheusServiceProvider.php.stub
@@ -19,7 +19,7 @@ use Spatie\Prometheus\Facades\Prometheus;
 
 class PrometheusServiceProvider extends ServiceProvider
 {
-    public function register()
+    public function register(): void
     {
         /*
          * Here you can register all the exporters that you

--- a/src/Facades/Prometheus.php
+++ b/src/Facades/Prometheus.php
@@ -16,7 +16,7 @@ use Spatie\Prometheus\MetricTypes\MetricType;
  */
 class Prometheus extends Facade
 {
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return \Spatie\Prometheus\Prometheus::class;
     }

--- a/src/Prometheus.php
+++ b/src/Prometheus.php
@@ -9,7 +9,7 @@ use Spatie\Prometheus\MetricTypes\MetricType;
 
 class Prometheus
 {
-    /** @var array<\Spatie\Prometheus\MetricTypes\MetricType> */
+    /** @var array<MetricType> */
     protected array $collectors = [];
 
     public function addGauge(

--- a/src/PrometheusServiceProvider.php
+++ b/src/PrometheusServiceProvider.php
@@ -30,7 +30,7 @@ class PrometheusServiceProvider extends PackageServiceProvider
             ->hasConfigFile();
     }
 
-    public function packageRegistered()
+    public function packageRegistered(): void
     {
         $this->app->singleton(Prometheus::class);
         $this->app->alias(Prometheus::class, 'prometheus');
@@ -43,7 +43,7 @@ class PrometheusServiceProvider extends PackageServiceProvider
         });
     }
 
-    public function packageBooted()
+    public function packageBooted(): void
     {
         $this->registerUrls();
     }

--- a/tests/Actions/RenderCollectorsActionTest.php
+++ b/tests/Actions/RenderCollectorsActionTest.php
@@ -2,11 +2,12 @@
 
 namespace Spatie\Prometheus\Tests\Actions;
 
+use Mockery\MockInterface;
 use Prometheus\CollectorRegistry;
 use Spatie\Prometheus\Actions\RenderCollectorsAction;
 
 it('does not wipe storage by default', closure: function () {
-    $mock = $this->mock(CollectorRegistry::class, function (\Mockery\MockInterface $mock) {
+    $mock = $this->mock(CollectorRegistry::class, function (MockInterface $mock) {
         $mock
             ->shouldReceive('getMetricFamilySamples')
             ->once()
@@ -22,7 +23,7 @@ it('does not wipe storage by default', closure: function () {
 it('wipes storage if config is set', closure: function () {
     config()->set('prometheus.wipe_storage_after_rendering', true);
 
-    $mock = $this->mock(CollectorRegistry::class, function (\Mockery\MockInterface $mock) {
+    $mock = $this->mock(CollectorRegistry::class, function (MockInterface $mock) {
         $mock
             ->shouldReceive('getMetricFamilySamples')
             ->once()

--- a/tests/Http/Controllers/PrometheusMetricsControllerTest.php
+++ b/tests/Http/Controllers/PrometheusMetricsControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\Prometheus\Facades\Prometheus;
+use Spatie\Prometheus\MetricTypes\Counter;
 use Spatie\Prometheus\MetricTypes\Gauge;
 use Spatie\Prometheus\Tests\TestSupport\Actions\TestRenderCollectorsAction;
 
@@ -27,7 +28,7 @@ it('can use a custom namespace', function () {
 });
 
 it('can render a gauge with all options', function () {
-    /** @var \Spatie\Prometheus\MetricTypes\Gauge $gauge */
+    /** @var Gauge $gauge */
     Prometheus::addGauge('my gauge')
         ->namespace('other_namespace')
         ->when(true, fn (Gauge $gauge): Gauge => $gauge->helpText('This is the help text'))
@@ -68,7 +69,7 @@ it('can render a gauge that returns a multiple results without labels in the clo
 });
 
 it('can render a gauge with labels', function () {
-    /** @var \Spatie\Prometheus\MetricTypes\Gauge $gauge */
+    /** @var Gauge $gauge */
     $gauge = Prometheus::addGauge('my gauge');
 
     $gauge
@@ -127,14 +128,14 @@ it('can replace default render collectors action', closure: function () {
 });
 
 it('can render a simple counter with initial value', function () {
-    /** @var \Spatie\Prometheus\MetricTypes\Counter $counter */
+    /** @var Counter $counter */
     Prometheus::addCounter('my counter');
 
     assertPrometheusResultsMatchesSnapshot();
 });
 
 it('can render a counter with all options', function () {
-    /** @var \Spatie\Prometheus\MetricTypes\Counter $counter */
+    /** @var Counter $counter */
     Prometheus::addCounter('my counter')
         ->namespace('other_namespace')
         ->helpText('This is the help text')
@@ -145,7 +146,7 @@ it('can render a counter with all options', function () {
 });
 
 it('can increment a counter by one as default', function () {
-    /** @var \Spatie\Prometheus\MetricTypes\Counter $counter */
+    /** @var Counter $counter */
     Prometheus::addCounter('my counter')
         ->setInitialValue(1)
         ->inc();
@@ -154,7 +155,7 @@ it('can increment a counter by one as default', function () {
 });
 
 it('can increment a counter by a custom value', function () {
-    /** @var \Spatie\Prometheus\MetricTypes\Counter $counter */
+    /** @var Counter $counter */
     $counter = Prometheus::addCounter('my counter');
     $counter->inc(2);
 
@@ -181,7 +182,7 @@ it('can render a counter that returns a multiple results with labels in the clos
 });
 
 it('can render a counter with labels', function () {
-    /** @var \Spatie\Prometheus\MetricTypes\Counter $counter */
+    /** @var Counter $counter */
     $counter = Prometheus::addCounter('my counter');
 
     $counter


### PR DESCRIPTION
## What
Added explicit return type declarations to the following methods:

- `PrometheusServiceProvider::register(): void` (stub)
- `PrometheusServiceProvider::packageRegistered(): void`
- `PrometheusServiceProvider::packageBooted(): void`
- `Prometheus::getFacadeAccessor(): string`

## Why
PHP 8+ best practices and static analysis tools (PHPStan, Psalm) expect explicit return types on overridden methods.
Without them, tools like PHPStan report missing return type warnings. This change improves type safety with no behaviour changes.

## Changes https://github.com/spatie/laravel-prometheus/pull/73/commits/ae66e3ea2b9bad0a032654a0b2a5b15d66532f9d
- `resources/stubs/PrometheusServiceProvider.php.stub`: added `void` to `register()`
- `docs/installation-setup.md`: added `void` to `register()`
- `src/PrometheusServiceProvider.php`: added `void` to `packageRegistered()` and `packageBooted()`
- `src/Facades/Prometheus.php`: added `string` to `getFacadeAccessor()`

## Testing
Non-breaking change, no existing behaviour is modified.
Tests can be added if required by the maintainer.