### PR TITLE
Rename FailedJobsPerHourCollector to FailedRecentJobsCollector

### DIFF
--- a/docs/basic-usage/using-horizon-exporters.md
+++ b/docs/basic-usage/using-horizon-exporters.md
@@ -14,7 +14,7 @@ This will register the following collectors:
 - `horizon_master_supervisors`: exports the number of master supervisors.
 - `horizon_current_processes`: exports the number of processes currently running per queue
 - `horizon_current_workload`: exports the number of jobs currently waiting per queue.
-- `horizon_failed_jobs_per_hour jobs`: exports the number of failed jobs in the past hour
+- `horizon_failed_recent_jobs`: exports the number of recently failed jobs
 - `horizon_status`: exports if the Horizon is running, paused, or inactive
 - `horizon_jobs_per_minute`: exports the number of jobs processed in the last minute
 - `horizon_recent_jobs`: exports the number of recent jobs

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -70,7 +70,7 @@ use Illuminate\Support\ServiceProvider;
 use Spatie\Prometheus\Collectors\Horizon\CurrentMasterSupervisorCollector;
 use Spatie\Prometheus\Collectors\Horizon\CurrentProcessesPerQueueCollector;
 use Spatie\Prometheus\Collectors\Horizon\CurrentWorkloadCollector;
-use Spatie\Prometheus\Collectors\Horizon\FailedJobsPerHourCollector;
+use Spatie\Prometheus\Collectors\Horizon\FailedRecentJobsCollector;
 use Spatie\Prometheus\Collectors\Horizon\HorizonStatusCollector;
 use Spatie\Prometheus\Collectors\Horizon\JobsPerMinuteCollector;
 use Spatie\Prometheus\Collectors\Horizon\RecentJobsCollector;
@@ -101,7 +101,7 @@ class PrometheusServiceProvider extends ServiceProvider
             CurrentMasterSupervisorCollector::class,
             CurrentProcessesPerQueueCollector::class,
             CurrentWorkloadCollector::class,
-            FailedJobsPerHourCollector::class,
+            FailedRecentJobsCollector::class,
             HorizonStatusCollector::class,
             JobsPerMinuteCollector::class,
             RecentJobsCollector::class,

--- a/resources/stubs/PrometheusServiceProvider.php.stub
+++ b/resources/stubs/PrometheusServiceProvider.php.stub
@@ -6,7 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Spatie\Prometheus\Collectors\Horizon\CurrentMasterSupervisorCollector;
 use Spatie\Prometheus\Collectors\Horizon\CurrentProcessesPerQueueCollector;
 use Spatie\Prometheus\Collectors\Horizon\CurrentWorkloadCollector;
-use Spatie\Prometheus\Collectors\Horizon\FailedJobsPerHourCollector;
+use Spatie\Prometheus\Collectors\Horizon\FailedRecentJobsCollector;
 use Spatie\Prometheus\Collectors\Horizon\HorizonStatusCollector;
 use Spatie\Prometheus\Collectors\Horizon\JobsPerMinuteCollector;
 use Spatie\Prometheus\Collectors\Horizon\RecentJobsCollector;
@@ -49,7 +49,7 @@ class PrometheusServiceProvider extends ServiceProvider
             CurrentMasterSupervisorCollector::class,
             CurrentProcessesPerQueueCollector::class,
             CurrentWorkloadCollector::class,
-            FailedJobsPerHourCollector::class,
+            FailedRecentJobsCollector::class,
             HorizonStatusCollector::class,
             JobsPerMinuteCollector::class,
             RecentJobsCollector::class,

--- a/src/Collectors/Horizon/FailedJobsPerHourCollector.php
+++ b/src/Collectors/Horizon/FailedJobsPerHourCollector.php
@@ -6,6 +6,9 @@ use Laravel\Horizon\Contracts\JobRepository;
 use Spatie\Prometheus\Collectors\Collector;
 use Spatie\Prometheus\Facades\Prometheus;
 
+/**
+ * @deprecated Use FailedRecentJobsCollector instead.
+ */
 class FailedJobsPerHourCollector implements Collector
 {
     public function register(): void

--- a/src/Collectors/Horizon/FailedRecentJobsCollector.php
+++ b/src/Collectors/Horizon/FailedRecentJobsCollector.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Prometheus\Collectors\Horizon;
+
+use Laravel\Horizon\Contracts\JobRepository;
+use Spatie\Prometheus\Collectors\Collector;
+use Spatie\Prometheus\Facades\Prometheus;
+
+class FailedRecentJobsCollector implements Collector
+{
+    public function register(): void
+    {
+        Prometheus::addGauge('Failed Recent Jobs')
+            ->name('horizon_failed_recent_jobs')
+            ->helpText('The number of recently failed jobs')
+            ->value(fn () => app(JobRepository::class)->countRecentlyFailed());
+    }
+}

--- a/tests/Collectors/Horizon/FailedRecentJobsCollectorTest.php
+++ b/tests/Collectors/Horizon/FailedRecentJobsCollectorTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use Spatie\Prometheus\Collectors\Horizon\FailedRecentJobsCollector;
+
+it('can register the failed recent jobs collector', function () {
+    app(FailedRecentJobsCollector::class)->register();
+
+    assertPrometheusResultsMatchesSnapshot();
+});


### PR DESCRIPTION
## Summary

Renames the `FailedJobsPerHourCollector` and its `horizon_failed_jobs_per_hour` metric to better reflect what they actually measure.

The collector returns the count from Horizon's `getRecentlyFailed()`, which covers the `recent_failed` trim window in `config/horizon.php` (default: one week, not one hour). The current naming is misleading and was previously raised in #44.

The count behaviour remains unchanged, only the naming was updated.

## Changes

- Add `FailedRecentJobsCollector` exposing the metric as `horizon_recent_failed_jobs`.
- Mark `FailedJobsPerHourCollector` as `@deprecated` 
- Update the stub service provider, installation docs, and Horizon exporter docs to reference the new collector.

## Backward compatibility

`FailedJobsPerHourCollector` was kept and still works. It's marked `@deprecated`.