### PR TITLE
Update method annotations in Prometheus-facade.

### DIFF
--- a/src/Facades/Prometheus.php
+++ b/src/Facades/Prometheus.php
@@ -8,10 +8,10 @@ use Spatie\Prometheus\MetricTypes\MetricType;
 /**
  * @see \Spatie\Prometheus\Prometheus
  *
- * @method static \Spatie\Prometheus\MetricTypes\Gauge addGauge(string $name)
- * @method static \Spatie\Prometheus\MetricTypes\Counter addCounter(string $name)
- * @method static \Spatie\Prometheus\Prometheus registerCollector(MetricType $collector)
- * @method static \Spatie\Prometheus\Prometheus registerCollectorClasses(array $collectors)
+ * @method static \Spatie\Prometheus\MetricTypes\Gauge addGauge(string $label, float|callable|null $value = null, ?string $name = null, ?string $namespace = null, ?string $helpText = null)
+ * @method static \Spatie\Prometheus\MetricTypes\Counter addCounter(string $label, int|callable|null $initialValue = null, ?string $name = null, ?string $namespace = null, ?string $helpText = null)
+ * @method static self registerCollector(MetricType $collector)
+ * @method static self registerCollectorClasses(array $collectors, array $constructorParameters = [])
  * @method static string renderCollectors(string $urlName = 'default')
  */
 class Prometheus extends Facade


### PR DESCRIPTION
# What

Updated the `@method` annotations in the `Prometheus`-facade:

- include the optional arguments in the annotations for `addGauge()`, `addCounter()` and `registerCollectorClasses()`
- switch return type of `registerCollector()` and `registerCollectorClasses()` to `self` to match the PHP type

# Why

Static analysis tools and IDEs rely on these annotations to provide code insights and report errors. When these annotations diverge from the actual implementation, tools report wrong warnings/errors and developers are mislead. This change improves type safety and developer experience with no behaviour changes.

# Testing

No actual code changes, no behaviour is modified.